### PR TITLE
[Fix/#50] date 포맷 수정

### DIFF
--- a/src/pages/ManageCar/Accident.js
+++ b/src/pages/ManageCar/Accident.js
@@ -36,7 +36,7 @@ const Accident = React.memo(() => {
     <div className="flex flex-col items-center w-full py-8 mt-12 bg-sky-50 rounded-2xl shadow-figma">
       {/* 타이틀 */}
       <div className="w-[700px] h-[35px] flex justify-between items-center text-blue-800 text-[30px] font-bold">
-        차량 수리 내역
+        차량 사고 내역
         {/* 내역 추가 버튼 */}
         <button
           className="h-full text-lg font-bold text-white rounded-lg w-28 bg-sky-600 hover:shadow-figma"
@@ -44,7 +44,7 @@ const Accident = React.memo(() => {
             const tmp = [...newAccident.accidents];
             tmp.push({
               title: "",
-              eventDate: dayjs(new Date()).format("YYYY-MM-DDTHH:mm:SS"),
+              eventDate: dayjs(new Date()).format("YYYY-MM-DDTHH:mm:ss"),
               content: "",
             });
             setNewAccident({ accidents: [...tmp] }); // 빈 객체 추가
@@ -73,7 +73,7 @@ const Accident = React.memo(() => {
                     const tmp = [...newAccident.accidents];
                     const newObj = {
                       ...tmp[i],
-                      eventDate: dayjs(date).format("YYYY-MM-DDTHH:mm:SS"),
+                      eventDate: dayjs(date).format("YYYY-MM-DDTHH:mm:ss"),
                     };
                     tmp.splice(i, 1, newObj);
                     setNewAccident({ accidents: [...tmp] }); // 변경 정보 저장

--- a/src/pages/ManageCar/Repair.js
+++ b/src/pages/ManageCar/Repair.js
@@ -44,7 +44,7 @@ const Repair = React.memo(() => {
             const tmp = [...newRepair.repairs];
             tmp.push({
               title: "",
-              eventDate: dayjs(new Date()).format("YYYY-MM-DDTHH:mm:SS"),
+              eventDate: dayjs(new Date()).format("YYYY-MM-DDTHH:mm:ss"),
               content: "",
             });
             setNewRepair({ repairs: [...tmp] }); // 빈 객체 추가
@@ -73,7 +73,7 @@ const Repair = React.memo(() => {
                     const tmp = [...newRepair.repairs];
                     const newObj = {
                       ...tmp[i],
-                      eventDate: dayjs(date).format("YYYY-MM-DDTHH:mm:SS"),
+                      eventDate: dayjs(date).format("YYYY-MM-DDTHH:mm:ss"),
                     };
                     tmp.splice(i, 1, newObj);
                     setNewRepair({ repairs: [...tmp] }); // 변경 정보 저장


### PR DESCRIPTION
시간에서의 초는 SS 가 아닌 ss

<!-- 풀 리퀘스트 제목
[<이슈 종류>/<이슈번호1>, <이슈번호2>] <제목>
-->

<!-- 리뷰어랑 담당자, 라벨 설정했는지 확인하세요 -->

## 🚀 Background
date 포맷 수정
<!-- 어떤 걸 고치고 pr을 했는지 간단하게 -->

## 🥥 Contents
### date 포맷
시간에서 "초" 의 경우 대문자 S 가 아닌 소문자 s 를 사용
```javascript
dayjs(new Date()).format("YYYY-MM-DDTHH:mm:ss") // 으로 사용
```

<!--
코드, 개발 관점에서 어떤걸 고쳤는지 상세하게
사진같은걸 넣어도 된다.
pr 보는 사람이 따로 정보를 안 찾아봐도 되게 적는게 이상적
-->

## 🧪 Testing

- [x] 데이터 반영 확인

<!-- 테스트 방법이나, 테스트 한 목록들을 적는다. -->

## 📸 Screenshot

<!-- 움짤을 넣어주는게 가장 좋고, 왠만하면 용량을 작게 만든다. -->

## ⚓ Related Issue
- #50 

close #50

<!-- 이슈 번호를 적어주면 되고, close 같은 자동 닫힘을 등록하여도 된다. -->

## 📚 Reference

<!-- 자신이 참조한 정보의 출처를 적는다. -->
