### PR TITLE
[Fix/#48] 리스트 검색 시 결과 없으면 alert로 없다고 출력

### DIFF
--- a/src/pages/Reservation/CarList/CarList.js
+++ b/src/pages/Reservation/CarList/CarList.js
@@ -6,6 +6,7 @@ import { altResvAtom, prevResvAtom } from "recoil/reservationAtom";
 import dayjs from "dayjs";
 import { getChangeableCarList, patchReservation } from "api/changeResvAxios";
 import { adminAtom } from "recoil/adminAtom";
+import { useAlert } from "utils/useAlert";
 
 const CarList = ({ setActiveStep }) => {
   function paddingList(list, MAX_ROW) {
@@ -51,6 +52,8 @@ const CarList = ({ setActiveStep }) => {
 
   // 팝업 state
   const [isPopUpShow, setIsPopUpShow] = useState(false);
+
+  const alert = useAlert();
 
   // 초기 useEffect
   useEffect(() => {
@@ -110,21 +113,25 @@ const CarList = ({ setActiveStep }) => {
                 className="ml-4 text-5xl text-blue-500"
                 onClick={() => {
                   if (findInput.trim() !== "") {
-                    setIsFinding(true);
-                    setPageNum(1);
-
-                    setMaxPageNum(
-                      Math.ceil(
-                        cars.filter((v) => v.carName === findInput).length /
-                          MAX_ROW
-                      )
-                    );
-
                     const findData = cars
                       .filter((v) => v.carName === findInput)
                       .slice(0, MAX_ROW);
 
-                    setListData(paddingList(findData, MAX_ROW));
+                    if (findData.length === 0) {
+                      alert.onAndOff("검색 결과가 없습니다.");
+                    } else {
+                      setIsFinding(true);
+                      setPageNum(1);
+
+                      setMaxPageNum(
+                        Math.ceil(
+                          cars.filter((v) => v.carName === findInput).length /
+                            MAX_ROW
+                        )
+                      );
+
+                      setListData(paddingList(findData, MAX_ROW));
+                    }
                   } else {
                     setIsFinding(false);
                     setMaxPageNum(Math.ceil(cars.length / MAX_ROW));
@@ -288,7 +295,6 @@ const CarList = ({ setActiveStep }) => {
                   <span>{`${rclAltResv.endTime}`}</span>
                 </div>
                 <div className="text-xl">
-                  <span>{`${rclAltResv.carName} `}</span>
                   <span>{`${rclAltResv.carNumber} 차량의 예약으로 변경하겠습니까?`}</span>
                 </div>
               </div>

--- a/src/pages/Reservation/Reservation.js
+++ b/src/pages/Reservation/Reservation.js
@@ -8,6 +8,9 @@ import {
 import ResvList from "./ResvList/ResvList";
 import DateTime from "./DateTime/DateTime";
 import CarList from "./CarList/CarList";
+import { useRecoilValue } from "recoil";
+import { alertAtom } from "recoil/alertAtom";
+import Alert from "popUp/Alert";
 
 const Reservation = () => {
   const [activeStep, setActiveStep] = useState(0);
@@ -16,6 +19,8 @@ const Reservation = () => {
 
   const handleNext = () => !isLastStep && setActiveStep((cur) => cur + 1);
   const handlePrev = () => !isFirstStep && setActiveStep((cur) => cur - 1);
+
+  const alertState = useRecoilValue(alertAtom);
 
   useEffect(() => {
     console.log(activeStep);
@@ -94,6 +99,7 @@ const Reservation = () => {
       {activeStep === 2 ? (
         <CarList setActiveStep={setActiveStep}></CarList>
       ) : null}
+      {alertState.state ? <Alert /> : null}
     </div>
   );
 };

--- a/src/pages/Reservation/ResvList/ResvList.js
+++ b/src/pages/Reservation/ResvList/ResvList.js
@@ -5,6 +5,7 @@ import { altResvAtom, prevResvAtom } from "recoil/reservationAtom";
 import dayjs from "dayjs";
 import { adminAtom } from "recoil/adminAtom";
 import { getResvList } from "api/changeResvAxios";
+import { useAlert } from "utils/useAlert";
 
 const ResvList = ({ handleNext }) => {
   function paddingList(list, MAX_ROW) {
@@ -52,6 +53,8 @@ const ResvList = ({ handleNext }) => {
 
   const adminInfo = useRecoilValue(adminAtom);
 
+  const alert = useAlert();
+
   // 초기 useEffect
   useEffect(() => {
     // 리스트 서버에서 받아오는 코드
@@ -95,14 +98,17 @@ const ResvList = ({ handleNext }) => {
                 className="ml-4 text-5xl text-blue-500"
                 onClick={() => {
                   if (findInput.trim() !== "") {
-                    setIsFinding(true);
-                    setPageNum(1);
-
                     const findData = resvs.filter(
                       (v) => v.nickname === findInput
                     );
 
-                    setListData(paddingList(findData, MAX_ROW));
+                    if (findData.length === 0) {
+                      alert.onAndOff("검색 결과가 없습니다.");
+                    } else {
+                      setIsFinding(true);
+                      setPageNum(1);
+                      setListData(paddingList(findData, MAX_ROW));
+                    }
                   } else {
                     setIsFinding(false);
                     setListData(


### PR DESCRIPTION


<!-- 풀 리퀘스트 제목
[<이슈 종류>/<이슈번호1>, <이슈번호2>] <제목>
-->

<!-- 리뷰어랑 담당자, 라벨 설정했는지 확인하세요 -->

## 🚀 Background

리스트 검색 시 결과 없으면 alert로 없다고 출력

마지막 예약 변경 전 확인 부분의 ui 변경

## 🥥 Contents

### 리스트 검색 시 결과 없으면 alert로 없다고 출력

``` js
const findData = cars
  .filter((v) => v.carName === findInput)
  .slice(0, MAX_ROW);
if (findData.length === 0) {
  alert.onAndOff("검색 결과가 없습니다.");
} else {
  setIsFinding(true);
  setPageNum(1);
  setMaxPageNum(
    Math.ceil(
      cars.filter((v) => v.carName === findInput).length /
        MAX_ROW
    )
  );
  setListData(paddingList(findData, MAX_ROW));
```

- 검색 input에다가 아무 문자를 넣지 않았을 경우에, 데이터를 일단 찾는다.
- 만약 찾아낸 데이터의 배열 길이가 0이면 데이터가 없다는 뜻이 된다.
- 사용자에게 데이터가 없음을 알리고 아무 행동도 하지 않는다.

### 예약 변경 최종 확인 시 알림창 변경

- 예약 변경 최종 확인 시 보여주는 ui의 변경

<!--
코드, 개발 관점에서 어떤걸 고쳤는지 상세하게
사진같은걸 넣어도 된다.
pr 보는 사람이 따로 정보를 안 찾아봐도 되게 적는게 이상적
-->

## 🧪 Testing

- [x] 없는 항목을 검색했을 경우 알림이 제대로 나온다.
- [x] 평소대로의 검색은 제대로 작동됨
- [x] 예약 최종 확인 팝업에서의 ui가 정상적으로 변경됨 

<!-- 테스트 방법이나, 테스트 한 목록들을 적는다. -->

## 📸 Screenshot

### 검색 결과

![carnofind](https://github.com/YU-RentCar/yurentcar-fe-admin/assets/54520200/5eeea123-209f-47be-8920-004beb50ad13)

![nocar](https://github.com/YU-RentCar/yurentcar-fe-admin/assets/54520200/d801e6f7-ece8-47fa-8226-84814a05937b)

### 마지막 확인 팝업

![lastpopup](https://github.com/YU-RentCar/yurentcar-fe-admin/assets/54520200/f9a09a2f-411e-46ca-8c9c-b2f7ef3fcd8b)

## ⚓ Related Issue

- #48 

close #48 

## 📚 Reference

<!-- 자신이 참조한 정보의 출처를 적는다. -->
