### PR TITLE
[Fix/#50] 상태 변경 시 UI 버그 수정

### DIFF
--- a/src/pages/CarState/CarState.js
+++ b/src/pages/CarState/CarState.js
@@ -159,7 +159,10 @@ const CarState = () => {
                                   afterChange: v, // 변화된 상태
                                 };
                                 tmp.splice(index, 1, after); // 바뀐 객체로 변경
-                                setNewInfo({ cars: [...tmp] });
+                                setNewInfo({
+                                  cars: [...tmp],
+                                  maxPage: { num: Math.ceil(tmp.length / 6) },
+                                });
                                 document.getElementById(`sort${i}`).innerText =
                                   v;
                               }}


### PR DESCRIPTION
<!-- 풀 리퀘스트 제목
[<이슈 종류>/<이슈번호1>, <이슈번호2>] <제목>
-->

<!-- 리뷰어랑 담당자, 라벨 설정했는지 확인하세요 -->

## 🚀 Background
페이지가 바뀌어도 UI 가 고정된채로 바뀌지 않는 버그 수정
<!-- 어떤 걸 고치고 pr을 했는지 간단하게 -->

## 🥥 Contents
### 페이지에 따라 UI 가 바뀌도록 수정
```javascript
// CarState.js
const after = {
  ...tmp[index],
  afterChange: v, // 변화된 상태
};
tmp.splice(index, 1, after); // 바뀐 객체로 변경
setNewInfo({
  cars: [...tmp],
  maxPage: { num: Math.ceil(tmp.length / 6) },
});
```
 - 바뀐 상태를 afterChange 임의의 값으로 저장
 - 리스트 업데이트 과정이 누락되어있음
 - 업데이트 과정 추가 (= maxPage 변경)
<!--
코드, 개발 관점에서 어떤걸 고쳤는지 상세하게
사진같은걸 넣어도 된다.
pr 보는 사람이 따로 정보를 안 찾아봐도 되게 적는게 이상적
-->

## 🧪 Testing

- [x] UI 가 고정되지 않고 유동적으로 바뀌는지 확인

<!-- 테스트 방법이나, 테스트 한 목록들을 적는다. -->

## 📸 Screenshot
### UI 고정 버그 수정
![carstatebugfix_gif](https://github.com/YU-RentCar/yurentcar-fe-admin/assets/86611398/0b428217-79b0-48c5-a3c5-4cfdcc264798)


<!-- 움짤을 넣어주는게 가장 좋고, 왠만하면 용량을 작게 만든다. -->

## ⚓ Related Issue
- #52 

close #52

<!-- 이슈 번호를 적어주면 되고, close 같은 자동 닫힘을 등록하여도 된다. -->

## 📚 Reference

<!-- 자신이 참조한 정보의 출처를 적는다. -->
