### PR TITLE
[Feat/#55] 차량 관리 UI 추가 구현 및 버그 수정

### DIFF
--- a/src/pages/ManageCar/DefaultInfo.js
+++ b/src/pages/ManageCar/DefaultInfo.js
@@ -43,7 +43,7 @@ const DefaultInfo = React.memo(() => {
             beforePrice: response.data.beforePrice,
             afterPrice: response.data.afterPrice,
             discountRate: response.data.discountRate,
-            discountReason: response.data.discountRate,
+            discountReason: response.data.discountReason,
             carDescription: response.data.carDescription,
             picture: response.data.photoUrl,
             isModified: false,

--- a/src/pages/ManageCar/DetailInfo.js
+++ b/src/pages/ManageCar/DetailInfo.js
@@ -62,26 +62,65 @@ const DetailInfo = React.memo(() => {
           <div className="w-[150px] h-[150px] bg-sky-50 flex flex-col justify-around rounded-xl mx-6 px-3 py-3">
             <MdLocalCarWash className="text-[45px]" />
             <span className="text-lg font-semibold">유종</span>
-            <div className="flex items-center">
-              <input
-                className="w-full px-2 text-base font-bold text-blue-900 border-2 border-blue-900 h-9 rounded-xl"
-                placeholder=""
-                value={newDetail.oilType}
-                onChange={(e) => setNewDetail({ oilType: e.target.value })}
-              />
-            </div>
+            {/* 휘발유, 경유, 수소, 전기 중 선택 */}
+            <Menu placement="bottom">
+              <MenuHandler>
+                <button className="flex items-center justify-around w-full px-2 text-base font-bold text-white bg-blue-400 rounded-xl h-9 ">
+                  <span id="oilType" className="font-bold">
+                    {newDetail.oilType}
+                  </span>
+                  <MdArrowBackIosNew className="-rotate-90" />
+                </button>
+              </MenuHandler>
+              <MenuList className="max-h-72">
+                {["휘발유", "경유", "수소", "전기"].map((v, i) => {
+                  return (
+                    <MenuItem
+                      className="flex items-center justify-center text-lg font-bold"
+                      onClick={() => {
+                        document.getElementById("oilType").innerText = v;
+                        setNewDetail({ oilType: v });
+                      }}
+                      key={i}
+                    >
+                      {v}
+                    </MenuItem>
+                  );
+                })}
+              </MenuList>
+            </Menu>
           </div>
           {/* 차량 크기 */}
           <div className="w-[150px] h-[150px] bg-sky-50 flex flex-col justify-around rounded-xl mx-6 px-3 py-3">
             <MdPhotoSizeSelectSmall className="text-[45px]" />
             <span className="text-lg font-semibold">차량 크기</span>
-            <div className="flex items-center">
-              <input
-                className="w-full px-2 text-base font-bold text-blue-900 border-2 border-blue-900 h-9 rounded-xl"
-                value={newDetail.carSize}
-                onChange={(e) => setNewDetail({ carSize: e.target.value })}
-              />
-            </div>
+            {/* 소형, 준중형, 중형, 대형 중 선택 */}
+            <Menu placement="bottom">
+              <MenuHandler>
+                <button className="flex items-center justify-around w-full px-2 text-base font-bold text-white bg-blue-400 rounded-xl h-9 ">
+                  <span id="carSize" className="font-bold">
+                    {newDetail.carSize}
+                  </span>
+                  <MdArrowBackIosNew className="-rotate-90" />
+                </button>
+              </MenuHandler>
+              <MenuList className="max-h-72">
+                {["소형", "준중형", "중형", "대형"].map((v, i) => {
+                  return (
+                    <MenuItem
+                      className="flex items-center justify-center text-lg font-bold"
+                      onClick={() => {
+                        document.getElementById("carSize").innerText = v;
+                        setNewDetail({ carSize: v });
+                      }}
+                      key={i}
+                    >
+                      {v}
+                    </MenuItem>
+                  );
+                })}
+              </MenuList>
+            </Menu>
           </div>
           {/* 출시일 */}
           <div className="w-[150px] h-[150px] bg-sky-50 flex flex-col justify-around rounded-xl mx-6 px-3 py-3">
@@ -186,13 +225,44 @@ const DetailInfo = React.memo(() => {
           <div className="w-[150px] h-[150px] bg-sky-50 flex flex-col justify-around rounded-xl mx-6 px-3 py-3">
             <MdTag className="text-[45px]" />
             <span className="text-lg font-semibold">브랜드</span>
-            <div className="flex items-center">
-              <input
-                className="w-full px-2 text-base font-bold text-blue-900 border-2 border-blue-900 h-9 rounded-xl"
-                value={newDetail.carBrand}
-                onChange={(e) => setNewDetail({ carBrand: e.target.value })}
-              />
-            </div>
+            {/* 현대, 기아, 제네시스, 르노삼성, 쌍용, BMW, 벤츠, 볼보, 아우디, 혼다 중 선택 */}
+            <Menu placement="bottom">
+              <MenuHandler>
+                <button className="flex items-center justify-around w-full px-2 text-base font-bold text-white bg-blue-400 rounded-xl h-9 ">
+                  <span id="carBrand" className="font-bold">
+                    {newDetail.carBrand}
+                  </span>
+                  <MdArrowBackIosNew className="-rotate-90" />
+                </button>
+              </MenuHandler>
+              <MenuList className="max-h-72">
+                {[
+                  "현대",
+                  "기아",
+                  "제네시스",
+                  "르노삼성",
+                  "쌍용",
+                  "BMW",
+                  "벤츠",
+                  "볼보",
+                  "아우디",
+                  "혼다",
+                ].map((v, i) => {
+                  return (
+                    <MenuItem
+                      className="flex items-center justify-center text-lg font-bold"
+                      onClick={() => {
+                        document.getElementById("carBrand").innerText = v;
+                        setNewDetail({ carBrand: v });
+                      }}
+                      key={i}
+                    >
+                      {v}
+                    </MenuItem>
+                  );
+                })}
+              </MenuList>
+            </Menu>
           </div>
           {/* 국산/외제 */}
           <div className="w-[150px] h-[150px] bg-sky-50 flex flex-col justify-around rounded-xl mx-6 px-3 py-3">

--- a/src/pages/ManageCar/ManageCar.js
+++ b/src/pages/ManageCar/ManageCar.js
@@ -70,7 +70,7 @@ const ManageCar = () => {
                         headers: {
                           "Content-Type": "multipart/form-data",
                         },
-                        baseURL: "http://be.yurentcar.kro.kr:1234/api/v1",
+                        baseURL: "http://deploytest.iptime.org:8080/api/v1",
                       }
                     )
                     .then((response) => {
@@ -89,7 +89,7 @@ const ManageCar = () => {
                         headers: {
                           "Content-Type": "multipart/form-data",
                         },
-                        baseURL: "http://be.yurentcar.kro.kr:1234/api/v1",
+                        baseURL: "http://deploytest.iptime.org:8080/api/v1",
                       }
                     )
                     .then((response) => {


### PR DESCRIPTION
<!-- 풀 리퀘스트 제목
[<이슈 종류>/<이슈번호1>, <이슈번호2>] <제목>
-->

<!-- 리뷰어랑 담당자, 라벨 설정했는지 확인하세요 -->

## 🚀 Background
- 차량 상세 정보 입력 UI 변경
- 잘못된 데이터 참조 수정
<!-- 어떤 걸 고치고 pr을 했는지 간단하게 -->

## 🥥 Contents
### 잘못된 데이터 참조 수정
할인 사유를 위한 데이터인 discountReason 을 할인율인 discountRate 를 참조하던 것을 수정
<br>

### 상세 정보 입력 UI -> Menu
``` javascript
// DetailInfo.js
{/* 휘발유, 경유, 수소, 전기 중 선택 */}
<Menu placement="bottom">
  <MenuHandler>
    <button>
      <span id="oilType" className="font-bold">
        {newDetail.oilType}
      </span>
    </button>
  </MenuHandler>
  <MenuList className="max-h-72">
    {["휘발유", "경유", "수소", "전기"].map((v, i) => {
      return (
        <MenuItem
          onClick={() => {
            document.getElementById("oilType").innerText = v;
            setNewDetail({ oilType: v });
          }} > {v} </MenuItem>
      );
    })}
  </MenuList>
</Menu>
```
- 기존에는 관리자가 직접 키보드로 일일이 입력하도록 구현
- Menu 를 통해 선택지를 제공
- 탑승 인원을 제외한 모든 상세 정보는 Menu 로 제공
- 데이터베이스에 없는 차량 스펙을 입력하는 것 또한 대비 가능

<!--
코드, 개발 관점에서 어떤걸 고쳤는지 상세하게
사진같은걸 넣어도 된다.
pr 보는 사람이 따로 정보를 안 찾아봐도 되게 적는게 이상적
-->

## 🧪 Testing

- [x] 할인 사유가 제대로 적용됐는지 확인
- [x] Menu 가 제대로 적용됐는지 확인

<!-- 테스트 방법이나, 테스트 한 목록들을 적는다. -->

## 📸 Screenshot
### 할인 사유
![carbug](https://github.com/YU-RentCar/yurentcar-fe-admin/assets/86611398/3d786c75-6dd1-4589-af9f-348210c47feb)
<br>

### 상세 정보 Menu
![carmenuui_gif](https://github.com/YU-RentCar/yurentcar-fe-admin/assets/86611398/7331181f-07a5-4472-9d98-2b8f79d60ffc)


<!-- 움짤을 넣어주는게 가장 좋고, 왠만하면 용량을 작게 만든다. -->

## ⚓ Related Issue
- #55 

close #55

<!-- 이슈 번호를 적어주면 되고, close 같은 자동 닫힘을 등록하여도 된다. -->

## 📚 Reference

<!-- 자신이 참조한 정보의 출처를 적는다. -->
