### PR TITLE
[Fix/#68] 공지사항 새로고침 버그 수정

### DIFF
--- a/src/pages/Notice/utils/useNotice.js
+++ b/src/pages/Notice/utils/useNotice.js
@@ -8,13 +8,14 @@ export const useNotice = function () {
   const adminInfo = useRecoilValue(adminAtom); // 관리자 정보
   const alert = useAlert(); // alert 제어
   const [info, setInfo] = useRecoilState(noticeInfoSelector); // 공지사항 관리 데이터 관리
+  const admin = JSON.parse(window.sessionStorage.getItem("adminInfo"));
 
   // controller
   const nu = {};
 
   // 공지사항 리스트 조회
   nu.getNoticeList = function () {
-    getNoticeList(adminInfo.province, adminInfo.branchName)
+    getNoticeList(admin.province, admin.branchName)
       .then((response) => {
         console.log("공지사항 / 조회 : ", response.data);
         const tmp = [...response.data];
@@ -52,7 +53,7 @@ export const useNotice = function () {
   };
   // 공지사항 검색
   nu.searchNotices = function (title) {
-    getNoticeList(adminInfo.province, adminInfo.branchName)
+    getNoticeList(admin.province, admin.branchName)
       .then((response) => {
         console.log("검색 / 조회 : ", response.data);
         const tmp = [];
@@ -74,7 +75,7 @@ export const useNotice = function () {
     deleteNotice("first_admin", noticeId)
       .then((response) => {
         console.log("공지 / 삭제 : ", response.data);
-        this.getNoticeList(adminInfo.province, adminInfo.branchName);
+        this.getNoticeList(admin.province, admin.branchName);
       })
       .catch((error) => console.log("공지 / 삭제에러 : ", error.response));
   };


### PR DESCRIPTION
<!-- 풀 리퀘스트 제목
[<이슈 종류>/<이슈번호1>, <이슈번호2>] <제목>
-->

<!-- 리뷰어랑 담당자, 라벨 설정했는지 확인하세요 -->

## 🚀 Background
공지사항 새로고침 버그 수정
<!-- 어떤 걸 고치고 pr을 했는지 간단하게 -->

## 🥥 Contents
### 공지사항 새로고침 버그 수정
```javascript
// useNotice.js
const admin = JSON.parse(window.sessionStorage.getItem("adminInfo"));

...

getNoticeList(admin.province, admin.branchName)
  .then((response) => {
    ...
```
- 세션스토리지에 저장된 정보를 직접 이용

<!--
코드, 개발 관점에서 어떤걸 고쳤는지 상세하게
사진같은걸 넣어도 된다.
pr 보는 사람이 따로 정보를 안 찾아봐도 되게 적는게 이상적
-->

## 🧪 Testing

- [x] 공지사항 새로고침 확인

<!-- 테스트 방법이나, 테스트 한 목록들을 적는다. -->

## 📸 Screenshot
<!-- 움짤을 넣어주는게 가장 좋고, 왠만하면 용량을 작게 만든다. -->

## ⚓ Related Issue
- #68 

close #68

<!-- 이슈 번호를 적어주면 되고, close 같은 자동 닫힘을 등록하여도 된다. -->

## 📚 Reference

<!-- 자신이 참조한 정보의 출처를 적는다. -->
